### PR TITLE
Fix for $HOME expansion on Mac OS X

### DIFF
--- a/mr/awsome/__init__.py
+++ b/mr/awsome/__init__.py
@@ -357,7 +357,7 @@ class EC2(object):
             if not os.path.exists(id_file):
                 log.error("The access-key-id file at '%s' doesn't exist." % id_file)
                 sys.exit(1)
-            key_file = os.path.abspath(os.path.expanduser(os.path.expendvars(key_file)))
+            key_file = os.path.abspath(os.path.expanduser(os.path.expandvars(key_file)))
             if not os.path.exists(key_file):
                 log.error("The secret-access-key file at '%s' doesn't exist." % key_file)
                 sys.exit(1)


### PR DESCRIPTION
os.path.expanduser does not seem to expand $HOME on Mac (only variations on ~), but os.path.expandvar does successfully expand $HOME (and any other variables in the path)

```
Python 2.6.1 (r261:67515, Jun 24 2010, 21:47:49)
[GCC 4.2.1 (Apple Inc. build 5646)] on darwin 
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> os.environ['HOME']
'/Users/david'
>>> os.path.expanduser('$HOME')
'$HOME'
>>> os.path.expanduser('$HOME/')
'$HOME/'
>>> os.path.expanduser('~')
'/Users/david'
>>> os.path.expanduser('~david')
'/Users/david'
>>> os.path.expandvars('$HOME')
'/Users/david'
```
