### PR TITLE
FIX: Change getargspec to getfullargspec

### DIFF
--- a/ploy/config.py
+++ b/ploy/config.py
@@ -217,7 +217,7 @@ class ConfigSection(MutableMapping):
                 if not callable(massage):
                     massage = self._config.massagers.get((None, key))
                     if callable(massage):
-                        if len(inspect.getargspec(massage.__call__).args) == 3:
+                        if len(inspect.getfullargspec(massage.__call__).args) == 3:
                             return (massage, (self.sectionname,))
                         else:
                             return (massage, (self.sectiongroupname, self.sectionname))


### PR DESCRIPTION
Changed in version 3.6: This method was previously documented as deprecated in favour of signature() in Python 3.5, but that decision has been reversed in order to restore a clearly supported standard interface for single-source Python 2/3 code migrating away from the legacy getargspec() API.

https://docs.python.org/3/library/inspect.html#inspect.getfullargspec